### PR TITLE
🔄 Update PR Description Replacement UI

### DIFF
--- a/pr_manager/templates/description_generator_form.html
+++ b/pr_manager/templates/description_generator_form.html
@@ -8,7 +8,7 @@
         <div class="control">
             <button class="button is-link is-fullwidth generate-button">
                 <span class="icon"><i class="fas fa-wand-magic-sparkles"></i></span>
-                <span>Generate New Description & Title</span>
+                <span>Generate & Replace PR Description</span>
             </button>
         </div>
     </div>

--- a/pr_manager/templates/view_pull_request.html
+++ b/pr_manager/templates/view_pull_request.html
@@ -198,6 +198,14 @@
                         <div class="p-3">
                             {% if selected_pr.body %}
                                 {% include 'markdown_container.html' with markdown=selected_pr.body id="current-desc" classes="content mb-5 p-3" %}
+                                <p>
+                                    <a href="https://github.com/{{ repo_owner }}/{{ repo_name }}/pull/{{ selected_pr.number }}"
+                                       target="_blank"
+                                       class="button is-ghost"
+                                    ><span>View on Github</span>
+                                        <span class="icon"><i class="fa-solid fa-arrow-up-right-from-square"></i></span>
+                                    </a>
+                                </p>
                             {% else %}
                                 <p class="is-size-5 mb-5 has-text-weight-light p-3">
                                     This PR has no description
@@ -208,8 +216,10 @@
                     {% endif %}
 
 
+
                     {% include 'description_generator_form.html' %}
                 {% endif %}
+
             </div>
 
             <div id="review-tab-container" class="tab-container is-hidden p-3 pb-0" data-tab-id="review">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "studio"
-version = "0.9.9"
+version = "0.9.10"
 description = "Flagship application to showcase the Arcane Engineer platform"
 authors = ["Marco lamina <marco@arcane.engineer>"]
 license = "MIT"


### PR DESCRIPTION
**✨ UI Enhancements**
- Update button text in [description_generator_form.html](https://github.com/arc-eng/studio/blob/pr-description-note/pr_manager/templates/description_generator_form.html) to "Generate & Replace PR Description" for clarity.
- Add a "View on Github" button in [view_pull_request.html](https://github.com/arc-eng/studio/blob/pr-description-note/pr_manager/templates/view_pull_request.html) to easily access the PR on GitHub.

**🔧 Version Update**
- Bump version in [pyproject.toml](https://github.com/arc-eng/studio/blob/pr-description-note/pyproject.toml) from 0.9.9 to 0.9.10.