### PR TITLE
🔍 Enhance PR Visualization and Navigation

### DIFF
--- a/pr_manager/templates/changes_tab.html
+++ b/pr_manager/templates/changes_tab.html
@@ -1,0 +1,34 @@
+<div class="table-container">
+    <table class="table is-fullwidth is-borderless">
+        <tbody>
+        {% for change in change_requests %}
+            <tr>
+                <td class="is-narrow">
+                    {% if change.completed %}
+                    <a href="{% url 'view_task' owner=repo_owner repo=repo_name task_id=change.task_id %}" class="button is-shadowless is-small">
+                        <span class="icon is-small">
+                            <i class="fa fa-eye"></i>
+                        </span>
+                    </a>
+                    {% else %}
+                    <span class="icon has-text-info is-small">
+                        <i class="fa fa-rotate fa-spin"></i>
+                    </span>
+                    {% endif %}
+
+                </td>
+
+                <td class="{% if not change.completed %}is-blinking{% endif %}">
+                    {{ change.prompt }}
+                </td>
+                <td class="is-narrow">
+                        <span class="has-font-weight-light is-family-monospace is-size-7">
+                            {{ change.created_at | timesince }}
+                        </span>
+                </td>
+
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/pr_manager/templates/review_generator_tab.html
+++ b/pr_manager/templates/review_generator_tab.html
@@ -15,7 +15,7 @@
             {% include 'markdown_container.html' with markdown=review.summary id="summary" classes="p-3 mb-5" %}
 
             {% for finding in review.findings.all %}
-                <div class="card p-0 mx-3 has-background-light is-shadowless" style="border: 1px solid rgb(214, 217, 224);">
+                <div class="card p-0 mx-3 has-background-light is-shadowless is-bordered">
 
                     <header class="card-header p-2 has-round-corners is-shadowless is-borderless"
                             data-file="{{ finding.file }}"

--- a/pr_manager/templates/view_pull_request.html
+++ b/pr_manager/templates/view_pull_request.html
@@ -61,6 +61,7 @@
     border-bottom: 1px solid rgb(214, 217, 224);
 }
 
+
 {% endblock %}
 
 {% block repo_content %}
@@ -110,7 +111,7 @@
                                 <td class="is-narrow has-text-grey has-text-right">{{ commit.commit.author.date|timesince }} ago</td>
                             </tr>
                         {% endfor %}
-                        {% if not change_request_task %}
+                        {% if not change_request_task or change_request_task.status == "completed" %}
                             <tr>
                                 <td class="is-narrow is-vcentered">
                                     <figure class="image is-32x32">
@@ -157,7 +158,14 @@
         <div class="column is-5">
             <div class="tabs mb-0 is-fullwidth is-boxed">
                 <ul>
-
+                    {% if change_requests %}
+                        <li id="changes-tab" class="tab" data-tab-id="changes">
+                            <a>
+                                <span class="icon is-small"><i class="fas fa-code"></i></span>
+                                <span>Changes</span>
+                            </a>
+                        </li>
+                    {% endif %}
                     <li id="review-tab" class="tab" data-tab-id="review">
                         <a>
                             <span class="icon is-small"><i class="fas fa-magnifying-glass"></i></span>
@@ -227,6 +235,11 @@
                     {% include 'review_generator_tab.html' %}
                 </p>
             </div>
+
+            <div id="changes-tab-container" class="tab-container is-hidden p-3 pb-0" data-tab-id="changes">
+                {% include 'changes_tab.html' %}
+            </div>
+
         </div>
 
     </div>
@@ -282,8 +295,6 @@
 
             $('#send-button').click(function() {
                 $(this).addClass('is-loading');
-                // Disable change request input
-                {#$('input[name="change_request"]').attr('disabled', 'disabled');#}
             });
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "studio"
-version = "0.9.10"
+version = "0.9.11"
 description = "Flagship application to showcase the Arcane Engineer platform"
 authors = ["Marco lamina <marco@arcane.engineer>"]
 license = "MIT"

--- a/tasks/templates/view_task.html
+++ b/tasks/templates/view_task.html
@@ -41,7 +41,7 @@
         <div class="column is-narrow">
             <div class="buttons">
                 {% if task.pr_number %}
-                    <a href="{% url 'view_pull_request' owner=repo_owner repo=repo_name pr_number=task.pr_number pr_tab="review" %}" class="button is-page-loader has-text-success-40">
+                    <a href="{% url 'view_pull_request' owner=repo_owner repo=repo_name pr_number=task.pr_number pr_tab="describe" %}" class="button is-page-loader has-text-success-40">
                         <span class="icon is-small"><i class="fas fa-code-branch"></i></span> <span>#{{ task.pr_number }}</span>
                     </a>
 
@@ -94,7 +94,7 @@
                             {% if task.pr_number %}
                                 <div class="control">
                                     <a class="button is-rounded"
-                                       href="{% url 'view_pull_request' owner=repo_owner repo=repo_name pr_number=task.pr_number pr_tab="review" %}">
+                                       href="{% url 'view_pull_request' owner=repo_owner repo=repo_name pr_number=task.pr_number pr_tab="describe" %}">
                                         <span class="icon"><i class="fa fa-code-branch"></i></span>
                                         <span>#{{ task.pr_number }}</span>
                                     </a>


### PR DESCRIPTION
This PR enhances the visualization and navigation of pull requests in the Arcane Studio application.

**✨ Templates**
- Added a new [changes_tab.html](https://github.com/arc-eng/studio/blob/visualize-pr-changes/pr_manager/templates/changes_tab.html) for displaying change requests.
- Updated [review_generator_tab.html](https://github.com/arc-eng/studio/blob/visualize-pr-changes/pr_manager/templates/review_generator_tab.html) to include bordered cards.
- Modified [view_pull_request.html](https://github.com/arc-eng/studio/blob/visualize-pr-changes/pr_manager/templates/view_pull_request.html) to integrate the changes tab and improve tab navigation.

**🔄 Views**
- Refactored `view_pull_request` in [views.py](https://github.com/arc-eng/studio/blob/visualize-pr-changes/pr_manager/views.py) to handle completed change requests and update task redirection.

**🔧 Configuration**
- Bumped version in [pyproject.toml](https://github.com/arc-eng/studio/blob/visualize-pr-changes/pyproject.toml) from 0.9.10 to 0.9.11.

**🔗 Task Navigation**
- Adjusted links in [view_task.html](https://github.com/arc-eng/studio/blob/visualize-pr-changes/tasks/templates/view_task.html) to redirect to the "describe" tab instead of "review".